### PR TITLE
feat: add coin details page and API caching

### DIFF
--- a/Backend/src/controllers/coinsController.ts
+++ b/Backend/src/controllers/coinsController.ts
@@ -1,10 +1,17 @@
 import type { Request, Response, NextFunction } from 'express';
 import axios from 'axios';
+import { getCache, setCache } from '../utils/cache';
 
 const COINGECKO_BASE_URL = 'https://api.coingecko.com/api/v3';
 
 export async function getCoins(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
+    const cacheKey = req.originalUrl;
+    const cached = getCache<any>(cacheKey);
+    if (cached) {
+      res.json(cached);
+      return;
+    }
     const { ids, vs_currency = 'usd', price_change_percentage } = req.query;
     
     const params: any = {
@@ -24,6 +31,7 @@ export async function getCoins(req: Request, res: Response, next: NextFunction):
     }
     
     const response = await axios.get(`${COINGECKO_BASE_URL}/coins/markets`, { params });
+    setCache(cacheKey, response.data, 60 * 1000);
     res.json(response.data);
   } catch (error: any) {
     if (error.response) {
@@ -39,6 +47,12 @@ export async function getCoins(req: Request, res: Response, next: NextFunction):
 
 export async function getCoinHistory(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
+    const cacheKey = req.originalUrl;
+    const cached = getCache<any>(cacheKey);
+    if (cached) {
+      res.json(cached);
+      return;
+    }
     const { id } = req.params;
     const { days = '7', interval } = req.query;
     
@@ -52,6 +66,7 @@ export async function getCoinHistory(req: Request, res: Response, next: NextFunc
     }
     
     const response = await axios.get(`${COINGECKO_BASE_URL}/coins/${id}/market_chart`, { params });
+    setCache(cacheKey, response.data, 60 * 1000);
     res.json(response.data);
   } catch (error: any) {
     if (error.response) {
@@ -67,6 +82,12 @@ export async function getCoinHistory(req: Request, res: Response, next: NextFunc
 
 export async function getCoinOHLC(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
+    const cacheKey = req.originalUrl;
+    const cached = getCache<any>(cacheKey);
+    if (cached) {
+      res.json(cached);
+      return;
+    }
     const { id } = req.params;
     const { vs_currency = 'usd', days = '7' } = req.query;
     
@@ -76,6 +97,7 @@ export async function getCoinOHLC(req: Request, res: Response, next: NextFunctio
     };
     
     const response = await axios.get(`${COINGECKO_BASE_URL}/coins/${id}/ohlc`, { params });
+    setCache(cacheKey, response.data, 60 * 1000);
     res.json(response.data);
   } catch (error: any) {
     if (error.response) {
@@ -91,6 +113,12 @@ export async function getCoinOHLC(req: Request, res: Response, next: NextFunctio
 
 export async function getBatchHistory(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
+    const cacheKey = req.originalUrl;
+    const cached = getCache<any>(cacheKey);
+    if (cached) {
+      res.json(cached);
+      return;
+    }
     const { ids } = req.query;
     
     if (!ids || typeof ids !== 'string') {
@@ -127,8 +155,9 @@ export async function getBatchHistory(req: Request, res: Response, next: NextFun
     });
     
     const results = await Promise.all(promises);
+    setCache(cacheKey, results, 60 * 1000);
     res.json(results);
   } catch (error) {
     next(error);
   }
-} 
+}

--- a/Backend/src/utils/cache.ts
+++ b/Backend/src/utils/cache.ts
@@ -1,0 +1,23 @@
+interface CacheEntry<T> {
+  data: T;
+  expiry: number;
+}
+
+const cache = new Map<string, CacheEntry<any>>();
+
+export function getCache<T>(key: string): T | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiry) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.data as T;
+}
+
+export function setCache<T>(key: string, data: T, ttl: number): void {
+  const expiry = Date.now() + ttl;
+  cache.set(key, { data, expiry });
+}
+
+export default { getCache, setCache };

--- a/Frontend/src/components/CoinCard/CoinCard.tsx
+++ b/Frontend/src/components/CoinCard/CoinCard.tsx
@@ -14,6 +14,7 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import { useTranslation } from 'react-i18next';
 import type { CryptoData } from '../../types/crypto';
+import { useNavigate } from 'react-router-dom';
 
 interface CoinCardProps {
   coin: CryptoData;
@@ -30,6 +31,7 @@ const CoinCard: React.FC<CoinCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const [showAuthAlert, setShowAuthAlert] = useState(false);
+  const navigate = useNavigate();
 
   const formatPrice = (price: number): string => {
     if (price >= 1) {
@@ -61,6 +63,10 @@ const CoinCard: React.FC<CoinCardProps> = ({
     }
   };
 
+  const handleCardClick = () => {
+    navigate(`/coins/${coin.id}`);
+  };
+
   const handleCloseAlert = () => {
     setShowAuthAlert(false);
   };
@@ -85,6 +91,7 @@ const CoinCard: React.FC<CoinCardProps> = ({
             borderColor: 'primary.main',
           },
         }}
+        onClick={handleCardClick}
       >
         <CardContent sx={{ p: 3, pb: 3, flexGrow: 1 }}>
           <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', mb: 3 }}>
@@ -124,7 +131,7 @@ const CoinCard: React.FC<CoinCardProps> = ({
             </Box>
 
             <IconButton
-              onClick={handleWatchlistToggle}
+              onClick={(e) => { e.stopPropagation(); handleWatchlistToggle(); }}
               size="small"
               sx={{
                 ml: 1,

--- a/Frontend/src/components/CoinDetails/CoinDetails.tsx
+++ b/Frontend/src/components/CoinDetails/CoinDetails.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Box, Container, Typography, CircularProgress, Paper } from '@mui/material';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { useTranslation } from 'react-i18next';
+import cryptoService from '../../services/cryptoService';
+import type { CryptoData, CryptoHistoryData } from '../../types/crypto';
+
+const CoinDetails: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const [coin, setCoin] = useState<CryptoData | null>(null);
+  const [history, setHistory] = useState<CryptoHistoryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!id) return;
+      try {
+        setLoading(true);
+        setError(null);
+        const [coinData] = await cryptoService.getCoins({
+          ids: id,
+          vs_currency: 'usd',
+          price_change_percentage: '24h',
+        });
+        const historyData = await cryptoService.getCoinHistory(id, { days: '7' });
+        setCoin(coinData);
+        setHistory(historyData);
+      } catch (err) {
+        console.error(err);
+        setError(t('dashboard.error'));
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [id, t]);
+
+  if (loading) {
+    return (
+      <Box sx={{ py: 8, textAlign: 'center' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error || !coin || !history) {
+    return (
+      <Box sx={{ py: 8, textAlign: 'center' }}>
+        <Typography color="error">{error || t('dashboard.error')}</Typography>
+      </Box>
+    );
+  }
+
+  const chartOptions: Highcharts.Options = {
+    title: { text: `${coin.name} Price` },
+    xAxis: { type: 'datetime' },
+    series: [
+      {
+        type: 'line',
+        name: coin.name,
+        data: history.prices.map(([timestamp, price]) => [timestamp, price]),
+      },
+    ],
+  };
+
+  return (
+    <Box sx={{ bgcolor: 'background.default', minHeight: '100vh', py: 4 }}>
+      <Container maxWidth="md">
+        <Paper
+          elevation={0}
+          sx={{
+            p: 4,
+            mb: 4,
+            borderRadius: 2,
+            border: 1,
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 4 }}>
+            <img src={coin.image} alt={coin.name} width={48} height={48} style={{ marginRight: 16 }} />
+            <Typography variant="h4" component="h1" sx={{ fontWeight: 700 }}>
+              {coin.name} ({coin.symbol.toUpperCase()})
+            </Typography>
+          </Box>
+          <Typography variant="h5" sx={{ mb: 2 }}>
+            ${coin.current_price.toLocaleString()}
+          </Typography>
+          <Typography color={coin.price_change_percentage_24h >= 0 ? 'success.main' : 'error.main'}>
+            {coin.price_change_percentage_24h.toFixed(2)}%
+          </Typography>
+        </Paper>
+
+        <Paper
+          elevation={0}
+          sx={{
+            p: 4,
+            borderRadius: 2,
+            border: 1,
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+          }}
+        >
+          <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+        </Paper>
+      </Container>
+    </Box>
+  );
+};
+
+export default CoinDetails;
+

--- a/Frontend/src/components/Header/Header.tsx
+++ b/Frontend/src/components/Header/Header.tsx
@@ -61,6 +61,7 @@ export default function Header() {
 
   const handleSignOut = () => {
     logout();
+    navigate('/');
   };
 
   const handleWatchlistClick = () => {

--- a/Frontend/src/components/LanguageDropdown/LanguageDropdown.tsx
+++ b/Frontend/src/components/LanguageDropdown/LanguageDropdown.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import LanguageIcon from '@mui/icons-material/Language';
 import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 

--- a/Frontend/src/context/AuthContext.tsx
+++ b/Frontend/src/context/AuthContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import authService from '../services/authService';

--- a/Frontend/src/main.tsx
+++ b/Frontend/src/main.tsx
@@ -11,6 +11,7 @@ import Dashboard from './components/Dashboard/Dashboard.tsx'
 import SignIn from './components/Auth/SignIn.tsx'
 import SignUp from './components/Auth/SignUp.tsx'
 import Profile from './components/Profile/Profile.tsx'
+import CoinDetails from './components/CoinDetails/CoinDetails.tsx'
 
 const router = createBrowserRouter([
   {
@@ -21,17 +22,21 @@ const router = createBrowserRouter([
         index: true,
         element: <Dashboard />
       },
-      {
+      { 
         path: "signin",
         element: <SignIn />
       },
       {
-        path: "signup", 
+        path: "signup",
         element: <SignUp />
       },
       {
         path: "profile",
         element: <Profile />
+      },
+      {
+        path: "coins/:id",
+        element: <CoinDetails />
       },
     ]
   },

--- a/Frontend/src/services/cryptoService.ts
+++ b/Frontend/src/services/cryptoService.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import type { CryptoData, CryptoHistoryData, WatchlistItem } from '../types/crypto';
+import type { CryptoData, CryptoHistoryData } from '../types/crypto';
 
 export const cryptoService = {
   // Get crypto market data
@@ -43,7 +43,7 @@ export const cryptoService = {
       days?: string;
       interval?: string;
     }
-  ): Promise<any[]> {
+  ): Promise<unknown[]> {
     const idsParam = coinIds.join(',');
     const response = await api.get('/api/coins/history', {
       params: { ids: idsParam, ...params },


### PR DESCRIPTION
## Summary
- add coin details page with price chart and navigation from dashboard
- cache coin data on backend to cut down external API calls
- redirect to home after signing out



